### PR TITLE
Integrate marker display api and close memory form GPT5

### DIFF
--- a/src/components/map/LeafletMap.tsx
+++ b/src/components/map/LeafletMap.tsx
@@ -9,6 +9,7 @@ import { Location, Memory } from '@/types/api';
 import Button from '@/components/ui/Button';
 import MemoryModal from '@/components/memories/MemoryModal';
 import { format } from 'date-fns';
+import MarkerDetailModal from '@/components/memories/MarkerDetailModal';
 
 // Fix for default markers in Next.js
 delete (Icon.Default.prototype as any)._getIconUrl;
@@ -77,10 +78,12 @@ const LeafletMap: React.FC<LeafletMapProps> = ({
   const [selectedLocation, setSelectedLocation] = useState<Location | null>(null);
   const [selectedMemory, setSelectedMemory] = useState<Memory | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [showMarkerDetailModal, setShowMarkerDetailModal] = useState(false);
 
   const handleLocationClick = useCallback((location: Location) => {
     setSelectedLocation(location);
     onLocationClick?.(location);
+    setShowMarkerDetailModal(true);
   }, [onLocationClick]);
 
   const handleAddMemory = useCallback((location: Location) => {
@@ -334,6 +337,14 @@ const LeafletMap: React.FC<LeafletMapProps> = ({
         memory={selectedMemory || undefined}
         onSuccess={handleModalSuccess}
       />
+
+      {showMarkerDetailModal && selectedLocation && (
+        <MarkerDetailModal
+          isOpen={showMarkerDetailModal}
+          onClose={() => setShowMarkerDetailModal(false)}
+          location={selectedLocation}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Integrate marker detail display on map clicks using the new API 2.2.

This change fulfills the user requirement to display memory and location details when a map marker is clicked. The memory creation form closing after submission was verified to be handled by existing modal and page navigation logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-49b57431-0be0-4a60-b51f-cd6f078b6f97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49b57431-0be0-4a60-b51f-cd6f078b6f97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

